### PR TITLE
feat:タグ機能を実装

### DIFF
--- a/src/app/Http/Requests/RecipeRequest.php
+++ b/src/app/Http/Requests/RecipeRequest.php
@@ -35,7 +35,8 @@ class RecipeRequest extends FormRequest
           'step_content5' => 'required|max:200',
           'step_content6' => 'required|max:200',
           'cooking_point' => 'required|max:200',
-          
+          // 半角スペースと「/」がないかをチェックする正規表現
+          'tags' => 'json|regex:/^(?!.*\s).+$/u|regex:/^(?!.*\/).*$/u',
         ];
     }
 
@@ -53,7 +54,17 @@ class RecipeRequest extends FormRequest
             'step_content5' => 'Step5',
             'step_content6' => 'Step6',
             'cooking_point' => 'コツ・ポイント',
+            'tags' => 'タグ',
         ];
+    }
+
+    public function passedValidation()
+    {
+        $this->tags = collect(json_decode($this->tags))
+            ->slice(0, 3)
+            ->map(function ($requestTag) {
+                return $requestTag->text;
+            });
     }
 
 }

--- a/src/app/Recipe.php
+++ b/src/app/Recipe.php
@@ -35,6 +35,12 @@ class Recipe extends Model
       return $this->belongsToMany('App\User', 'likes')->withTimestamps();
   }
 
+  // タグモデルとのリレーション
+  public function tags(): BelongsToMany
+  {
+      return $this->belongsToMany('App\Tag')->withTimestamps();
+  }
+
   // あるユーザーがいいね済みかどうかを判定するメソッド
   public function isLikedBy(?User $user): bool
   {
@@ -50,6 +56,7 @@ class Recipe extends Model
   {
       return $this->likes->count();
   }
+  
 
 
 }

--- a/src/app/Tag.php
+++ b/src/app/Tag.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+  protected $fillable = [
+    'name',
+  ];
+}

--- a/src/resources/js/components/RecipeTagsInput.vue
+++ b/src/resources/js/components/RecipeTagsInput.vue
@@ -22,10 +22,16 @@ export default {
   components: {
     VueTagsInput,
   },
+  props: {
+    initialTags: {
+      type: Array,
+      default: [],
+    },
+  },  
   data() {
     return {
       tag: '',
-      tags: [],
+      tags: this.initialTags, 
       autocompleteItems: [{
         text: 'Spain',
       }, {

--- a/src/resources/views/recipes/card.blade.php
+++ b/src/resources/views/recipes/card.blade.php
@@ -104,6 +104,18 @@
         </recipe-like>
       </div>
     </div>
-
+    @foreach($recipe->tags as $tag)
+      @if($loop->first)
+        <div class="card-body pt-0 pb-4 pl-3">
+          <div class="card-text line-height">
+      @endif
+            <a href="" class="border p-1 mr-1 mt-1 text-muted">
+              {{ $tag->name }}
+            </a>
+      @if($loop->last)
+          </div>
+        </div>
+      @endif
+    @endforeach
   </div>
 </div>

--- a/src/resources/views/recipes/form.blade.php
+++ b/src/resources/views/recipes/form.blade.php
@@ -48,6 +48,7 @@
 </div>
 <div class="form-group">
   <recipe-tags-input
+  :initial-tags='@json($tagNames ?? [])'
   >
   </recipe-tags-input>
 </div>


### PR DESCRIPTION
やったこと
1. タグモデルの作成とレシピモデルの編集
2. タグ情報のバリデーション
3. レシピ投稿時にタグをつけられるようにするためにタグモデルを編集
4. 記事の一覧画面・詳細画面でタグを表示できるように編集
5. 記事編集時に登録していたタグを表示するようにした