### PR TITLE
feat:レシピ更新時に画像が必須になってしまっていたので、URLよって表示される項目を変更

### DIFF
--- a/src/app/Http/Requests/RecipeRequest.php
+++ b/src/app/Http/Requests/RecipeRequest.php
@@ -26,7 +26,7 @@ class RecipeRequest extends FormRequest
         return [
           'recipe_title' => 'required|max:50',
           'content' => 'required|max:200',
-          'image_path' => 'required|file|mimes:jpeg,png,jpg,gif|max:2048',
+          'image_path' => 'file|mimes:jpeg,png,jpg,gif|max:2048',
           'ingredient' => 'required|max:200',
           'seasoning' => 'required|max:200',
           'step_content' => 'max:200',

--- a/src/resources/views/recipes/form.blade.php
+++ b/src/resources/views/recipes/form.blade.php
@@ -14,29 +14,34 @@
   <div class="form-input__picture afterimage">
     <!-- image_pathの中身がNULLじゃない場合は画像を表示させる -->
     @if (isset($recipe->image_path))
-      <!-- <img src="{{ asset("storage/images/$recipe->image_path") }}"  width="1000" height="300"> -->
-      <img src="/storage/images/{{$recipe->image_path}}"  width="1000" height="300">
       <div class="card-text">
-        <!-- <file-upload></file-upload> -->
-        <!-- <input type="file" name="image_path"> -->
+        <img src="/storage/images/{{$recipe->image_path}}"  width="1000" height="300">
       </div>
     @else
-      <span class="form-input__image_path--text">画像が登録されていません</span>
       <div class="card-text">
-        <!-- <file-upload></file-upload> -->
-        <!-- <input type="file" name="image_path"> -->
+        <span class="form-input__image_path--text">画像が登録されていません</span>
       </div>
     @endif
   </div>
 </div>
-
-<div class="form-group">
-  <div class="card-text">
-          <!-- <file-upload></file-upload> -->
-    <input type="file" name="image_path">
+  
+@if(Route::is('recipes.edit'))
+  <div class="form-group">
+    <div class="card-text">
+      <p>編集</p>
+      <!-- <file-upload></file-upload> -->
+      <input type="file" name="image_path">
+    </div>
   </div>
-</div>
-
+@else
+  <div class="form-group">
+    <div class="card-text">
+      <!-- <file-upload></file-upload> -->
+      <p>作成</p>
+      <input type="file" name="image_path" required>
+    </div>
+  </div>
+@endif
 
 <div class="form-group">
   <select class="form-control" name="serving">


### PR DESCRIPTION
レシピ投稿時に画像を必須な設計にしていたが、投稿と更新のフォームを共通化したことで更新処理でも画像が必須となってしまい不便になってた。

そこでURLで条件分岐を行い、共通化したまま画像アップロード必須かどうかの切り分けを行いました。
新規作成時には画像の投稿を必須とし、更新時には画像の投稿は任意としました。