### PR TITLE
style:フォームのデザイン修正

### DIFF
--- a/src/resources/sass/app.scss
+++ b/src/resources/sass/app.scss
@@ -4,22 +4,57 @@
   background-image: linear-gradient(315deg, #f39f86 0%, #f9d976 74%);
 }
 
+/*全体*/
 .hidden_box {
-  margin: 2em 0;/*前後の余白*/
-  padding: 0;
+  position: relative;
+  margin: 2em 0;
+  padding: 0.5em 1em;
+  border: solid 3px #C0C0C0;
+  border-radius: 8px;
 }
 
 /*ボタン装飾*/
 .hidden_box label {
   padding: 15px;
   font-weight: bold;
-  border: solid 2px black;
+  background: #efefef;
+  border-radius: 5px;
   cursor :pointer;
+  transition: .5s;
+  
+  position: absolute;
+  display: inline-block;
+  top: -13px;
+  left: 10px;
+  padding: 0 9px;
+  line-height: 1;
+  font-size: 19px;
+  background: #FFF;
+  color:#C0C0C0;
+  font-weight: bold;
 }
 
-/*ボタンホバー時*/
-.hidden_box label:hover {
-  background: #efefef;
+/*アイコンを表示*/
+.hidden_box label:before {
+  display: inline-block;
+  content: '\f078';
+  font-family: 'FontAwesome';
+  padding-right: 5px;
+  transition: 0.2s;
+}
+
+// /*ボタンホバー時*/
+// .hidden_box label:hover {
+//   // background: silver;
+// }
+
+/*アイコンを切り替え*/
+.hidden_box input:checked + label:before {
+    content: '\f00d';
+    -ms-transform: rotate(360deg);
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
+    color: #668ad8;
 }
 
 /*チェックは見えなくする*/
@@ -37,8 +72,48 @@
 }
 
 /*クリックで中身表示*/
-.hidden_box input:checked ~ .hidden_show {
+.hidden_box input:checked + label + .hidden_show {
   padding: 10px 0;
   height: auto;
   opacity: 1;
 }
+
+
+// .hidden_box {
+//   margin: 2em 0;/*前後の余白*/
+//   padding: 0;
+// }
+
+// /*ボタン装飾*/
+// .hidden_box label {
+//   padding: 15px;
+//   font-weight: bold;
+//   border: solid 2px black;
+//   cursor :pointer;
+// }
+
+// /*ボタンホバー時*/
+// .hidden_box label:hover {
+//   background: #efefef;
+// }
+
+// /*チェックは見えなくする*/
+// .hidden_box input {
+//   display: none;
+// }
+
+// /*中身を非表示にしておく*/
+// .hidden_box .hidden_show {
+//   height: 0;
+//   padding: 0;
+//   overflow: hidden;
+//   opacity: 0;
+//   transition: 0.8s;
+// }
+
+// /*クリックで中身表示*/
+// .hidden_box input:checked ~ .hidden_show {
+//   padding: 10px 0;
+//   height: auto;
+//   opacity: 1;
+// }

--- a/src/resources/views/app.blade.php
+++ b/src/resources/views/app.blade.php
@@ -7,8 +7,6 @@
   <title>
     @yield('title')
   </title>
-  <link href="{{ asset('css/app.css') }}" rel="stylesheet">
-
   <!-- Font Awesome -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.2/css/all.css">
   <!-- Bootstrap core CSS -->

--- a/src/resources/views/recipes/form.blade.php
+++ b/src/resources/views/recipes/form.blade.php
@@ -1,3 +1,6 @@
+
+<!-- 非表示の項目を開くときに使ってるアイコン -->
+<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
 @csrf
 <div class='md-form'>
   <label>レシピタイトル *</label>
@@ -43,35 +46,33 @@
   </div>
 @endif
 
-<div class="form-group">
-  <select class="form-control" name="serving">
-    @foreach ($servings as $serving => $serving_name)
-          <!-- <option value="{{ $serving }}"> -->
-      <option value="{{ $serving }}" {{ old('serving_name', $recipe->serving ?? '') == $serving ? 'selected' : ''}}>
-          {{ $serving_name }}
-      </option>
-    @endforeach
-  </select>
-</div>
-
 
 <div class="hidden_box">
-    <label for="label1">クリックして表示</label>
-    <input type="checkbox" id="label1"/>
-    <div class="hidden_show">
-      <!--非表示ここから-->
-      <textarea name="ingredient" class="form-control" required value="{{ $recipe->ingredient ?? old('ingredient') }}" placeholder="材料"></textarea>
-      <textarea type="text" name="seasoning" class="form-control" required value="{{ $recipe->seasoning ?? old('seasoning') }}" placeholder="調味料"></textarea>
-      <!--ここまで-->
+  <input type="checkbox" id="label1"/>
+  <label for="label1">材料、調味料</label>
+  <div class="hidden_show">
+    <!--非表示ここから-->
+    <div class="form-group">
+      <select class="form-control" name="serving">
+        @foreach ($servings as $serving => $serving_name)
+              <!-- <option value="{{ $serving }}"> -->
+          <option value="{{ $serving }}" {{ old('serving_name', $recipe->serving ?? '') == $serving ? 'selected' : ''}}>
+              {{ $serving_name }}
+          </option>
+        @endforeach
+      </select>
     </div>
+    <textarea name="ingredient" class="form-control" required value="{{ $recipe->ingredient ?? old('ingredient') }}" placeholder="材料"></textarea>
+    <textarea type="text" name="seasoning" class="form-control" required value="{{ $recipe->seasoning ?? old('seasoning') }}" placeholder="調味料"></textarea>
+    <!--ここまで-->
+  </div>
 </div>
 
 
   <div class="hidden_box">
-    <label for="label2">クリックして表示</label>
     <input type="checkbox" id="label2"/>
+    <label for="label2">調理手順</label>
     <div class="hidden_show">
-
       <div class="md-form">
         <p>Step1</p>
         <textarea type="text" name="step_content" class="form-control" value="{{ $recipe->step_content ?? old('step_content') }}"></textarea>


### PR DESCRIPTION
### 修正点
- 閉じてる時と開いてる時でそれぞれアイコンを表示することでUXを高めました。
- 隠された要素を枠で囲うことでユーザーがクリックした際にどこまでが開かられたのかをわかりやすくしました
- 何人前の項目が材料、調味料のボックスの中に移動させました

### 改善点
機能自体はこれで問題はないと思いますが、周りのデザインから浮きすぎているので合わせるように修正していきます。

#### 修正後
開く前
<img width="1239" alt="スクリーンショット 2021-11-15 17 51 48" src="https://user-images.githubusercontent.com/36786134/141751760-5531d419-edfe-44b0-a15a-c2edb33989e4.png">

開いた後
<img width="1278" alt="スクリーンショット 2021-11-15 17 51 55" src="https://user-images.githubusercontent.com/36786134/141751768-3b009566-6d99-4a9e-aac7-581e80cbf446.png">

#### 修正前
開く前
![スクリーンショット 2021-11-15 17 17 48](https://user-images.githubusercontent.com/36786134/141752033-87821872-47e5-4164-ba19-c1992687e48f.png)

開いた後
![スクリーンショット 2021-11-15 17 17 53](https://user-images.githubusercontent.com/36786134/141752040-32e7eb93-3379-4c08-bccf-8f5812a63ddb.png)