### PR TITLE
style:マイページのプロフィールカードのデザイン修正、ユーザー情報編集のデザイン修正

### DIFF
--- a/src/resources/js/components/FollowButton.vue
+++ b/src/resources/js/components/FollowButton.vue
@@ -2,6 +2,7 @@
   <div>
     <button
       class="btn-sm shadow-none border border-primary p-2"
+
       :class="buttonColor"
       @click="clickFollow" 
     >

--- a/src/resources/sass/app.scss
+++ b/src/resources/sass/app.scss
@@ -184,3 +184,13 @@ button.btn--circle:hover i {
   margin-left: 6px;
   opacity: 0.8;
 }
+
+// ボタンに丸みをつける
+#btn-radius{
+  border-radius: 100px;
+}
+// 
+
+
+
+

--- a/src/resources/views/users/edit.blade.php
+++ b/src/resources/views/users/edit.blade.php
@@ -9,88 +9,88 @@
     <div id="profile-edit-form" class="container">
       @include('error_card_list')
       @include('flash_message')
-        <div class="row">
-            <div class="col-8 offset-2 bg-white my-5">
-                <div class="font-weight-bold text-center border-bottom pb-3 pt-3" style="font-size: 24px">プロフィール編集</div>
+        <div class="container my-3">
+          <div class="row">
+
+            <div class="col-md-8 col-lg-8 mx-auto">
+              <!-- <div class="font-weight-bold text-center border-bottom pb-3 pt-3" style="font-size: 24px">
+                プロフィール編集
+              </div> -->
                 <form method="POST" class="p-5" action="{{ route('users.update',[$user->name]) }}" enctype="multipart/form-data">
-                    @csrf
-                    {{-- アイコン --}}
-                    <span class="avatar-form image-picker">
-                        <input type="file" name="profile_image" class="d-none"  id="profile_image"/>
-                        <label for="profile_image" class="d-inline-block">
-                        @if($user->profile_image !== NULL)
-                          <img src="/storage/icons/{{$user->profile_image}}" class="rounded-circle" style="object-fit: cover; width: 200px; height: 200px;">
+                  @csrf
+                  <!-- Card -->
+                  <div class="card testimonial-card">
+                    <!-- Background color -->
+                    <div class="card-up warning-color-dark p-3 white-text">
+                      <span>
+                        <i class="fas fa-arrow-left"></i>
+                      </span>
+                      <span class="font-weight-normal ml-3">プロフィールを編集する</span>
+                    </div>
+                    <!-- Avatar -->
+                    <!-- <div class="avatar mr-auto white"> -->
+                    <div class="d-flex flex-row mx-auto my-3">
+                          <span class="avatar-form image-picker">
+                              <input type="file" name="profile_image" class="d-none"  id="profile_image"/>
+                              <label for="profile_image" class="d-inline-block">
+                              @if($user->profile_image !== NULL)
+                                <img src="/storage/icons/{{$user->profile_image}}" class="rounded-circle" style="object-fit: cover; width: 200px; height: 200px;">
+                              @else
+                                <img src="/storage/default_icon.png" class="rounded-circle" style="object-fit: cover; width: 200px; height: 200px;">
+                              @endif
+                              </label>
+                          </span>
+                    </div>
+                    <div class="form-group mx-3 my-2">
+                        <div class="md-form">
+                          <input maxlength="50" type="text" id="name" class="form-control" name="name" value="{{ old('name', $user->name) }}" required autocomplete="name" autofocus>
+                          <label for="name">名前</label>
+                        </div>
+                    </div>
+
+                    <div class="form-group mx-3">
+                        <div class="md-form">
+                          <textarea id="self_introduction" maxlength="150" name="self_introduction" class="md-textarea form-control" rows="3">{{ old('self_introduction', $user->self_introduction) }}</textarea>
+                          <label for="self_introduction">自己紹介</label>
+                        </div>
+                    </div>
+                    
+                    <div class="form-group mx-2 text-center">
+                      <button type="submit" class="btn btn-outline-dark rounded w-75"  data-mdb-ripple-color="dark">
+                        保存
+                      </button>
+                    </div>
+
+                  <!-- </div> -->
+                  <!-- Card end-->
+              <!-- </form> -->
+                    <div class="card-body px-3 py-4">
+                      <div class="row">
+                        @if (Auth::id() == 1)
+                            <!-- ゲストユーザーの場合はパスワード変更のリンクを表示させないようにする -->
                         @else
-                          <img src="/storage/default_icon.png" class="rounded-circle" style="object-fit: cover; width: 200px; height: 200px;">
+                          <a href="{{ route('password.form', ['name' => $user->name]) }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+                            <dl class="mb-0">
+                              <dt>パスワードの変更</dt>
+                              <dd class="mb-0"></dd>
+                            </dl>
+                            <div><i class="fas fa-chevron-right"></i></div>
+                          </a>
+                          <a href="{{ route('email_change.form', ['name' => $user->name]) }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+                            <dl class="mb-0">
+                              <dt>メールアドレスの変更</dt>
+                              <dd class="mb-0"></dd>
+                            </dl>
+                            <div><i class="fas fa-chevron-right"></i></div>
+                          </a>
                         @endif
-                        </label>
-                    </span>
-
-                    <div class="form-group mt-3">
-                        <label for="name">ニックネーム</label>
-                        <input maxlength="50" id="name" type="text" class="form-control @error('name') is-invalid @enderror" name="name" value="{{ old('name', $user->name) }}" required autocomplete="name" autofocus>
-                        @error('name')
-                        <span class="invalid-feedback" role="alert">
-                            <!-- <strong>{{ $message }}</strong> -->
-                        </span>
-                        @enderror
-                    </div>
-                    <!-- <div class="form-group mt-3">
-                        <label for="email">メールアドレス</label>
-                        <input id="email" type="text" class="form-control @error('name') is-invalid @enderror" name="email" value="{{ old('email', $user->email) }}" required autocomplete="name" autofocus>
-                        @error('name')
-                        <span class="invalid-feedback" role="alert">
-                            <strong>{{ $message }}</strong>
-                        </span>
-                        @enderror
-                    </div> -->
-
-                    <div class="form-group mt-3">
-                        <label for="self_introduction">自己紹介</label>
-                        
-                        <textarea  maxlength="150" id="self_introduction" name="self_introduction" style="height: 100px;" class="form-control">{{ old('self_introduction', $user->self_introduction) }}</textarea>
-
-                        <!-- @error('name')
-                        <span class="invalid-feedback" role="alert">
-                        </span>
-                        @enderror -->
-                    </div>
-
-                    <div class="form-group mb-0 mt-3">
-                        <button type="submit" class="btn btn-block btn-secondary">
-                            保存
-                        </button>
+                      </div>
                     </div>
                 </form>
-                @if (Auth::id() == 1)
-                  <!-- ゲストユーザーの場合はパスワード変更のリンクを表示させないようにする -->
-                @else
-                  <a href="{{ route('password.form', ['name' => $user->name]) }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                    <dl class="mb-0">
-                      <dt>パスワードの変更</dt>
-                      <dd class="mb-0"></dd>
-                    </dl>
-                    <div><i class="fas fa-chevron-right"></i></div>
-                  </a>
-                  <a href="{{ route('email_change.form', ['name' => $user->name]) }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
-                    <dl class="mb-0">
-                      <dt>メールアドレスの変更</dt>
-                      <dd class="mb-0"></dd>
-                    </dl>
-                    <div><i class="fas fa-chevron-right"></i></div>
-                  </a>
-                @endif
+              </div>
             </div>
+          </div>
         </div>
-    </div>
+      </div>
+
 @endsection
-<!-- 
-                    <div class="form-group mb-0 mt-3">
-                      <a href="{{ route('password.form', ['name' => $user->name]) }}">
-                        <button class="btn blue-gradient btn-block" >
-                        <button class="btn blue-gradient btn-block" style="width: 25%; padding: 10px;">
-                          {{ __('Change Password') }}
-                          パスワードの変更
-                        </button>
-                      </a>
-                    </div> -->

--- a/src/resources/views/users/likes.blade.php
+++ b/src/resources/views/users/likes.blade.php
@@ -7,14 +7,13 @@
   <div class="container">
     
     @include('users.user')
-    {{ $recipes->count() }}件
-
     @include('users.tabs', ['hasRecipes' => true, 'hasLikes' => false])
       @foreach($recipes as $recipe)
         @include('recipes.card')
       @endforeach
-      <div class="container">
-        {{ $recipes->links() }}
-      </div>
+
+    <div class="container">
+      {{ $recipes->links() }}
+    </div>
   </div>
 @endsection

--- a/src/resources/views/users/show.blade.php
+++ b/src/resources/views/users/show.blade.php
@@ -8,9 +8,8 @@
   @include('flash_message')
   <div class="container">
     @include('users.user')
-    {{ $recipes->count() }}件
-
-    @include('users.tabs', ['hasRecipes' => true, 'hasLikes' => false])
+    
+      @include('users.tabs', ['hasRecipes' => true, 'hasLikes' => false])
       @foreach($recipes as $recipe)
         @include('recipes.card')
       @endforeach

--- a/src/resources/views/users/tabs.blade.php
+++ b/src/resources/views/users/tabs.blade.php
@@ -1,16 +1,14 @@
-
-
 <ul class="nav nav-tabs nav-justified mt-3">
   <li class="nav-item">
-    <a class="nav-link text-muted {{ $hasRecipes ? 'active' : '' }}"
-        href="{{ route('users.show', ['name' => $user->name]) }}" data-toggle="tab">
-      レシピ
+    <a class="nav-link text-muted tab {{ $hasRecipes ? 'active' : '' }}"
+        href="{{ route('users.show', ['name' => $user->name]) }}">
+        レシピ
     </a>
   </li>
   <li class="nav-item">
     <a class="nav-link text-muted {{ $hasLikes ? 'active' : '' }}"
-        href="{{ route('users.likes', ['name' => $user->name]) }}" data-toggle="tab">
-      いいね
+        href="{{ route('users.likes', ['name' => $user->name]) }}">
+          いいね
     </a>
   </li>
 </ul>

--- a/src/resources/views/users/user.blade.php
+++ b/src/resources/views/users/user.blade.php
@@ -1,55 +1,87 @@
-<div class="card mt-3">
-  <div class="card-body">
-    <div class="d-flex flex-row">
-      <a href="{{ route('users.show', ['name' => $user->name]) }}" class="text-dark">
-        @if($user->profile_image !== NULL)
-          <!-- <img src="/storage/icons{{$user->profile_image}}" class="rounded-circle" style="object-fit: cover; width: 200px; height: 200px;"> -->
-          <img src="/storage/icons/{{$user->profile_image}}" class="rounded-circle" style="object-fit: cover; width: 200px; height: 200px;">
-        @else
-          <img src="/storage/default_icon.png" class="rounded-circle" style="object-fit: cover; width: 200px; height: 200px;">
-        @endif
-      </a>
-      @if( Auth::id() !== $user->id )
-        <follow-button
-          class="ml-auto"
-          :initial-is-followed-by='@json($user->isFollowedBy(Auth::user()))'
-          :authorized='@json(Auth::check())'
-          endpoint="{{ route('users.follow', ['name' => $user->name]) }}"
-        >
-        </follow-button>
-      @else
-        <div class="ml-auto">
-          <a href="{{ route('users.edit', ['name' => $user->name] )}}">
-            <!-- <button class="user-btn"> -->
-            <button class="btn-sm btn-primary p-2" >
-              プロフィール編集
-            </button>
-          </a>
-        </div>
-      @endif
-    </div>
-    <h2 class="h5 card-title m-0">
-      <a href="{{ route('users.show', ['name' => $user->name]) }}" class="text-dark">
-        {{ $user->name }}
-      </a>
-      <p></p>
-    </h2>
+<div class="container mt-3">
+  <div class="row">
+    <div class="col-md-8 col-lg-12 mx-auto">
+      <!-- Section: Block Content -->
+      <section>
+        <!-- Card -->
+        <div class="card testimonial-card">
+            <!-- Background color -->
+            <div class="card-up warning-color-dark p-3 white-text">
+              <span>
+                <i class="fas fa-arrow-left">backで前のページに戻るようにする</i>
+              </span>
+              <a class="font-weight-normal ml-3">{{ $user->name }}</a>
+              
+            </div>
+            <!-- Avatar -->
+            <!-- <div class="avatar mr-auto white"> -->
+              <div class="d-flex flex-row my-2 mx-2">
+                <a href="{{ route('users.show', ['name' => $user->name]) }}" class="text-dark">
+                  @if($user->profile_image !== NULL)
+                    <!-- <img src="/storage/icons{{$user->profile_image}}" class="rounded-circle" style="object-fit: cover; width: 200px; height: 200px;"> -->
+                    <img src="/storage/icons/{{$user->profile_image}}" class="rounded-circle" style="object-fit: cover; width: 100px; height: 100px;">
+                  @else
+                    <img src="/storage/default_icon.png" class="rounded-circle" style="object-fit: cover; width: 100px; height: 100px;">
+                  @endif
+                </a>
+                @if( Auth::id() !== $user->id )
+                  <follow-button
+                    class="ml-auto"
+                    :initial-is-followed-by='@json($user->isFollowedBy(Auth::user()))'
+                    :authorized='@json(Auth::check())'
+                    endpoint="{{ route('users.follow', ['name' => $user->name]) }}"
+                  >
+                  </follow-button>
+                @else
+                  <div class="ml-auto">
+                    <a href="{{ route('users.edit', ['name' => $user->name] )}}">
+                      <button class="btn btn-outline-dark btn-rounded p-2" id="btn-radius">
+                        プロフィール編集
+                      </button>
+                    </a>
+                  </div>
+                @endif
+              </div>
+            <!-- </div> -->
+            <h2 class="h5 card-title ml-3">
+              <a href="{{ route('users.show', ['name' => $user->name]) }}" class="text-dark">
+                {{ $user->name }}
+              </a>
+            </h2>
+            <p class="text-dark mx-3">
+                {{ $user->self_introduction }}
+            </p>
 
-    <br>
-    <p class="text-dark">
-        {{ $user->self_introduction }}
-    </p>
+
+            <!-- Content -->
+            <div class="card-body px-3 py-4">
+              <div class="row">
+                <div class="col-4 text-center">
+                  <p class="font-weight-bold mb-0 text-muted">{{ $recipes->count() }}</p>
+                  <p class="small text-uppercase mb-0">件の投稿</p>
+                </div>
+                <div class="col-4 text-center border-left border-right">
+                  <a class="font-weight-bold mb-0 text-muted" href="{{ route('users.followings', ['name' => $user->name]) }}">
+                    {{ $user->count_followings }}
+                  </a>
+                  <p class="small text-uppercase mb-0">フォロー</p>
+                </div>
+                <div class="col-4 text-center">
+                  <a class="font-weight-bold mb-0 text-muted" href="{{ route('users.followers', ['name' => $user->name]) }}">
+                    {{ $user->count_followers }}
+                  </a>
+                  <p class="small text-uppercase mb-0">フォロワー</p>
+                </div>
+              </div>
+            </div>
+
+          </div>
+          <!-- Card -->
+
+      </section>
+      <!-- Section: Block Content -->
 
 
-  </div>
-  <div class="card-body">
-    <div class="card-text">
-      <a href="{{ route('users.followings', ['name' => $user->name]) }}" class="text-muted">
-        {{ $user->count_followings }} フォロー
-      </a>
-      <a href="{{ route('users.followers', ['name' => $user->name]) }}" class="text-muted">
-        {{ $user->count_followers }} フォロワー
-      </a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
### 修正前
<img width="901" alt="スクリーンショット 2021-12-22 0 47 58" src="https://user-images.githubusercontent.com/36786134/146959382-25645800-92d0-475b-ab12-93debb349670.png">

### 修正後
<img width="726" alt="スクリーンショット 2021-12-22 0 49 35" src="https://user-images.githubusercontent.com/36786134/146959370-992727c0-c683-41bc-9ea1-69ec7fd1c17a.png">

修正前はスマホに非対応だったのでデザインの修正とともにスマホにも対応しました。

### プロフィールカード
マイページのプロフィールカードも似たようなデザインになっています。
<img width="1120" alt="スクリーンショット 2021-12-22 0 54 23" src="https://user-images.githubusercontent.com/36786134/146959900-51158ad1-26d1-43fd-8bc0-5e1c9eac5e15.png">
