### PR TITLE
[refactor]InterventionImageの利用の記述を変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,6 @@ services:
       MYSQL_PASSWORD: ${DB_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
       TZ: 'Asia/Tokyo'
-    
     volumes:
       - mysql-volume:/var/lib/mysql
 

--- a/src/app/Http/Controllers/RecipeController.php
+++ b/src/app/Http/Controllers/RecipeController.php
@@ -6,11 +6,10 @@ namespace App\Http\Controllers;
 use App\Http\Requests\RecipeRequest;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
-// use Illuminate\Http\UploadedFile;
-use InterventionImage; // エイリアスを使用している
-use Storage;
-// use Intervention\Image\Facades\Image; // Imageファサードを使う
-// use Illuminate\Support\Facades\Storage; // Storageファサードを使う
+use Intervention\Image\Facades\Image as InterventionImage;
+use Illuminate\Support\Facades\Storage as Storage;
+// use InterventionImage; // エイリアスを使用している
+// use Storage;
 use App\Recipe;
 use App\Tag;
 use App\Category;
@@ -147,15 +146,16 @@ class RecipeController extends Controller
         $fileNameToStore = $fileName.".".$extension;
         // ローカルでの処理
         // $form['image_path']にユニークなファイル名を代入する
-        // $form['image_path'] = $fileNameToStore;
+        $form['image_path'] = $fileNameToStore;
         // ファイルディレクトリに保存する処理。
-        // Storage::put('public/images/'. $fileNameToStore, $resizedImage);
-        // S3への画像アップロード
-        // $path = Storage::disk('s3')->putFile('myprefix', $resizedImage ,'public');
-        $path = Storage::disk('s3')->putFile('myprefix', $fileNameToStore ,'public');
-        // アップロードした画像のフルパスを取得
-        $form['image_path'] = Storage::disk('s3')->url($path);
-        // dd($form['image_path']);
+        Storage::put('public/images/'. $fileNameToStore, $resizedImage);
+        
+        // // S3への画像アップロード
+        // // $path = Storage::disk('s3')->putFile('myprefix', $resizedImage ,'public');
+        // $path = Storage::disk('s3')->putFile('myprefix', $fileNameToStore ,'public');
+        // // アップロードした画像のフルパスを取得
+        // $form['image_path'] = Storage::disk('s3')->url($path);
+        // // dd($form['image_path']);
 
         // １、S３に保存するのは画像自体を保存する。リサイズした画像しかりね。
         // ２、DBにはS3にアップロードした画像のファイルを置いてる場所、ファイルパスを保存することでViewで参照できるようになる。

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -229,6 +229,7 @@ return [
         'Validator' => Illuminate\Support\Facades\Validator::class,
         'View' => Illuminate\Support\Facades\View::class,
         'InterventionImage' => Intervention\Image\Facades\Image::class,
+        // 'Image' => Intervention\Image\Facades\Image::class,
 
     ],
 


### PR DESCRIPTION
InterventionImageを利用する際に
use InterventionImage という風にエイリアスを利用していたが、調査の際にディレクトリを追うのがわかりづらいので
use Intervention\Image\Facades\Image as InterventionImageという風な記述に変更した。

これにより使っているファザードのディレクトリの場所とどんなエイリアスをつけているかがわかりやすくなるはず。