### PR TITLE
[fix]404が解決したのでS3へ画像をアップロードする処理を追加

### DIFF
--- a/src/app/Http/Controllers/RecipeController.php
+++ b/src/app/Http/Controllers/RecipeController.php
@@ -173,7 +173,7 @@ class RecipeController extends Controller
           // $file->storeAs('/', $file, 's3');
 
           // 成功
-          // Storage::disk('s3')->putFile('/', $file);
+          Storage::disk('s3')->putFile('/', $file);
           // Storage::disk('s3')->putFile('/', $resized_image);
           // Storage::disk('s3')->putFile('/laravel-ci-myprefix', $file);
           


### PR DESCRIPTION
DBのデータを一部削除したら404が解決。あまりよろしくないので、できる限りやらないように気をつけたい…

レシピ一覧ページが表示されるようになったので、S3へのアップロード処理のコメントアウトを解除しました。