### PR TITLE
[feat]S3の画像を取得するメソッドでurlメソッドを使用してたのgetに変更

### DIFF
--- a/src/app/Http/Controllers/RecipeController.php
+++ b/src/app/Http/Controllers/RecipeController.php
@@ -171,8 +171,8 @@ class RecipeController extends Controller
           
           // $resized_image->storeAs('/', $filename_to_store, 's3');
           // $file->storeAs('/', $file, 's3');
-
           // 成功
+          // S3にリサイズした画像をオリジナルのファイル名でアップロードする
           Storage::disk('s3')->put('/public/images/'. $filename_to_store, $resized_image);
           // $path = Storage::disk('s3')->put('/public/images/', $resized_image, 'public');
           // $form['image_path'] = Storage::disk('s3')->url($path);

--- a/src/resources/views/recipes/index_card.blade.php
+++ b/src/resources/views/recipes/index_card.blade.php
@@ -13,7 +13,7 @@
           </div>
         @else
           <div class="bg-image hover-overlay ripple" data-mdb-ripple-color="light">
-            <img src="{{ Storage::disk('s3')->url("/public/images/{$recipe->image_path}") }}">
+            <img src="{{ Storage::disk('s3')->get("/public/images/{$recipe->image_path}") }}">
           </div>
         @endif
         <div class="card-body">


### PR DESCRIPTION
[対象]index_card.blade.php

[変更理由]
urlメソッドは「保存したファイルの絶対バスが取得できる」というものだったが、S3にはファイルパスではなく画像が保存されているはずなので、getメソッドの方が適切だと判断したため。
