### PR TITLE
[feat]二重投稿の対策を実装 close #595

### DIFF
--- a/src/app/Http/Controllers/CommentController.php
+++ b/src/app/Http/Controllers/CommentController.php
@@ -24,6 +24,7 @@ class CommentController extends Controller
   }
   public function store(Request $request)
   {
+      // $request->session()->regenerateToken();
       // Commentモデル作成
       $comment = new Comment;
       $comment->comment = $request->comment;
@@ -31,6 +32,8 @@ class CommentController extends Controller
       $comment->user_id = Auth::user()->id;
       $comment->save();
 
+      // 二重送信対策
+      $request->session()->regenerateToken();
       // 直前にリダイレクト
       return redirect()->back()->with('comment_flash_message', 'コメントを投稿しました');
   }  

--- a/src/app/Http/Controllers/RecipeController.php
+++ b/src/app/Http/Controllers/RecipeController.php
@@ -157,11 +157,9 @@ class RecipeController extends Controller
           $form['image_path'] = $filename_to_store;
           // ファイルディレクトリに保存する処理。
           Storage::put('public/images/'. $filename_to_store, $resized_image);
-          
         }
         // 本番環境での処理
         else{
-          // 成功
           // ユニークなファイル名をimage_pathカラムに代入
           $form['image_path'] = 'public/images/'. $filename_to_store;
           // S3にリサイズした画像をオリジナルのファイル名でアップロードする
@@ -169,22 +167,19 @@ class RecipeController extends Controller
         }
       }
       
-      // $recipe->categories()->sync($request->id);
       $recipe->user_id = $request->user()->id;
       $recipe->fill($form)->save();
+      // 二重送信対策
+      $request->session()->regenerateToken();
+
       // カテゴリーを追加
       $recipe->categories()->attach($request->category_id);
-
       $request->tags->each(function ($tagName) use ($recipe) {
         $tag = Tag::firstOrCreate(['name' => $tagName]);
         $recipe->tags()->attach($tag);
       });
 
-      // $request->categories->each(function ($categoryName) use ($recipe) {
-      //   $category = Category::firstOrCreate(['name' => $categoryName]);
-      //   $recipe->categories()->attach($category);
-      // });
-      // toastr.info('これはinfo型のトーストです');
+      $request->session()->regenerateToken();
       return redirect()->route('recipes.index')->with('flash_message', 'レシピの投稿が完了しました');
   }
 

--- a/src/resources/js/app.js
+++ b/src/resources/js/app.js
@@ -11,6 +11,7 @@
 
 
 import './bootstrap'
+import './disableButton'
 
 import Vue from 'vue'
 

--- a/src/resources/js/disableButton.js
+++ b/src/resources/js/disableButton.js
@@ -1,0 +1,6 @@
+$(function(){
+  // 送信ボタンがクリックされたら、送信ボタンを非活性化する（二重submit対策）
+  $('form').submit(function() {
+    $("button[type='submit']").prop("disabled", true);
+  });
+});

--- a/src/resources/views/comments/form.blade.php
+++ b/src/resources/views/comments/form.blade.php
@@ -3,8 +3,8 @@
   <!-- <a class="light-color post-time no-text-decoration" href="/recipes/{{ $recipe->id }}">{{ $recipe->created_at }}</a> -->
   <div class="row actions" id="comment-form-post-{{ $recipe->id }}">
       <!-- <form class="w-100" id="new_comment" action="/recipe/{{ $recipe->id }}/comments" accept-charset="UTF-8" data-remote="true" method="post"><input name="utf8" type="hidden" value="&#x2713;" /> -->
+      @csrf
       <form class="w-100" id="new_comment" action="{{ route('comments.store', ['recipe' => $recipe]) }}"accept-charset="UTF-8" data-remote="true" method="post"><input name="utf8" type="hidden" value="&#x2713;" />
-      {{csrf_field()}} 
       <input value="{{ Auth::user()->id }}" type="hidden" name="user_id" />
       <input value="{{ $recipe->id }}" type="hidden" name="recipe_id" />
       <div class="md-form form-lg">

--- a/src/resources/views/recipes/form.blade.php
+++ b/src/resources/views/recipes/form.blade.php
@@ -111,7 +111,7 @@
       </div>
 
       <div class="md-outline">
-        <textarea maxlength="100" placeholder="Step5" rows="3" name="step_content5" class="form-control">{{ $recipe->step_content5 ?? old('step_content5') }}</textarea>
+        <textarea maxlength="100" v-model="recipeStep5Count" placeholder="Step5" rows="3" name="step_content5" class="form-control">{{ $recipe->step_content5 ?? old('step_content5') }}</textarea>
         <!-- <textarea maxlength="100" v-model="recipeStep5Count" placeholder="Step5" rows="3" name="step_content5" class="form-control">{{ $recipe->step_content5 ?? old('step_content5') }}</textarea>
         <p class="text-right">@{{ recipeStep5Count.length }}/100</p> -->
       </div>


### PR DESCRIPTION
レシピ投稿とコメント投稿時に連続してボタンを押すと複数の投稿ができてしまう問題を修正

対応
・Laravel側ではcsrfトークンを利用して二重submitを防止
・javascriptでsubmitボタンのDisable化